### PR TITLE
Setting private_instance_id to allow gorouter sticky sessions

### DIFF
--- a/router_client.go
+++ b/router_client.go
@@ -18,6 +18,7 @@ type RouterClient interface {
 
 type CFRouterClient struct {
 	Host       string
+	PrivateInstanceId string
 	messageBus yagnats.NATSClient
 
 	registry *Registry
@@ -28,9 +29,10 @@ type CFRouterClient struct {
 }
 
 type RegistryMessage struct {
-	URIs []string `json:"uris"`
-	Host string   `json:"host"`
-	Port int      `json:"port"`
+	URIs []string             `json:"uris"`
+	Host string               `json:"host"`
+	Port int                  `json:"port"`
+	PrivateInstanceId string  `json:"private_instance_id"`
 }
 
 type RouterGreetingMessage struct {
@@ -38,8 +40,13 @@ type RouterGreetingMessage struct {
 }
 
 func NewCFRouterClient(host string, messageBus yagnats.NATSClient) *CFRouterClient {
+	u4, err := uuid.NewV4()
+	if err != nil {
+		log.Printf("failed to create UUID as private instance id: %s\n", err)
+	}
 	return &CFRouterClient{
 		Host: host,
+		PrivateInstanceId: u4.String(),
 
 		registry: NewRegistry(),
 
@@ -108,6 +115,7 @@ func (r *CFRouterClient) sendRegistryMessage(subject string, port int, uris []st
 		URIs: uris,
 		Host: r.Host,
 		Port: port,
+		PrivateInstanceId: r.PrivateInstanceId,
 	}
 
 	json, err := json.Marshal(msg)

--- a/router_client_test.go
+++ b/router_client_test.go
@@ -21,7 +21,7 @@ func (s *RCSuite) TestRouterClientRegistering(c *C) {
 
 	routerClient.Register(123, "abc")
 
-	registrations := mbus.PublishedMessages["router.register"]
+	registrations := mbus.PublishedMessages("router.register")
 
 	c.Assert(len(registrations), Not(Equals), 0)
 	c.Assert(string(registrations[0].Payload), Equals, `{"uris":["abc"],"host":"1.2.3.4","port":123}`)
@@ -34,7 +34,7 @@ func (s *RCSuite) TestRouterClientUnregistering(c *C) {
 
 	routerClient.Unregister(123, "abc")
 
-	unregistrations := mbus.PublishedMessages["router.unregister"]
+	unregistrations := mbus.PublishedMessages("router.unregister")
 
 	c.Assert(len(unregistrations), Not(Equals), 0)
 	c.Assert(string(unregistrations[0].Payload), Equals, `{"uris":["abc"],"host":"1.2.3.4","port":123}`)
@@ -48,30 +48,30 @@ func (s *RCSuite) TestRouterClientRouterStartHandling(c *C) {
 	err := routerClient.Greet()
 	c.Assert(err, IsNil)
 
-	startCallback := mbus.Subscriptions["router.start"][0]
+	startCallback := mbus.Subscriptions("router.start")[0]
 	startCallback.Callback(&yagnats.Message{
 		Payload: []byte(`{"minimumRegisterIntervalInSeconds":1}`),
 	})
 
 	routerClient.Register(123, "abc")
 
-	c.Assert(len(mbus.PublishedMessages["router.register"]), Equals, 1)
+	c.Assert(len(mbus.PublishedMessages("router.register")), Equals, 1)
 
 	time.Sleep(600 * time.Millisecond)
 
-	c.Assert(len(mbus.PublishedMessages["router.register"]), Equals, 1)
+	c.Assert(len(mbus.PublishedMessages("router.register")), Equals, 1)
 
 	time.Sleep(600 * time.Millisecond)
 
-	c.Assert(len(mbus.PublishedMessages["router.register"]), Equals, 2)
+	c.Assert(len(mbus.PublishedMessages("router.register")), Equals, 2)
 
 	time.Sleep(600 * time.Millisecond)
 
-	c.Assert(len(mbus.PublishedMessages["router.register"]), Equals, 2)
+	c.Assert(len(mbus.PublishedMessages("router.register")), Equals, 2)
 
 	time.Sleep(600 * time.Millisecond)
 
-	c.Assert(len(mbus.PublishedMessages["router.register"]), Equals, 3)
+	c.Assert(len(mbus.PublishedMessages("router.register")), Equals, 3)
 }
 
 func (s *RCSuite) TestRouterClientGreeting(c *C) {
@@ -84,28 +84,28 @@ func (s *RCSuite) TestRouterClientGreeting(c *C) {
 	err := routerClient.Greet()
 	c.Assert(err, IsNil)
 
-	greetMsg := mbus.PublishedMessages["router.greet"][0]
+	greetMsg := mbus.PublishedMessages("router.greet")[0]
 
-	greetCallback := mbus.Subscriptions[greetMsg.ReplyTo][0]
+	greetCallback := mbus.Subscriptions(greetMsg.ReplyTo)[0]
 	greetCallback.Callback(&yagnats.Message{
 		Payload: []byte(`{"minimumRegisterIntervalInSeconds":1}`),
 	})
 
-	c.Assert(len(mbus.PublishedMessages["router.register"]), Equals, 1)
+	c.Assert(len(mbus.PublishedMessages("router.register")), Equals, 1)
 
 	time.Sleep(600 * time.Millisecond)
 
-	c.Assert(len(mbus.PublishedMessages["router.register"]), Equals, 1)
+	c.Assert(len(mbus.PublishedMessages("router.register")), Equals, 1)
 
 	time.Sleep(600 * time.Millisecond)
 
-	c.Assert(len(mbus.PublishedMessages["router.register"]), Equals, 2)
+	c.Assert(len(mbus.PublishedMessages("router.register")), Equals, 2)
 
 	time.Sleep(600 * time.Millisecond)
 
-	c.Assert(len(mbus.PublishedMessages["router.register"]), Equals, 2)
+	c.Assert(len(mbus.PublishedMessages("router.register")), Equals, 2)
 
 	time.Sleep(600 * time.Millisecond)
 
-	c.Assert(len(mbus.PublishedMessages["router.register"]), Equals, 3)
+	c.Assert(len(mbus.PublishedMessages("router.register")), Equals, 3)
 }

--- a/router_client_test.go
+++ b/router_client_test.go
@@ -24,7 +24,8 @@ func (s *RCSuite) TestRouterClientRegistering(c *C) {
 	registrations := mbus.PublishedMessages("router.register")
 
 	c.Assert(len(registrations), Not(Equals), 0)
-	c.Assert(string(registrations[0].Payload), Equals, `{"uris":["abc"],"host":"1.2.3.4","port":123}`)
+	c.Assert(string(registrations[0].Payload), Equals,
+		`{"uris":["abc"],"host":"1.2.3.4","port":123,"private_instance_id":"` + routerClient.PrivateInstanceId + `"}`)
 }
 
 func (s *RCSuite) TestRouterClientUnregistering(c *C) {
@@ -37,7 +38,8 @@ func (s *RCSuite) TestRouterClientUnregistering(c *C) {
 	unregistrations := mbus.PublishedMessages("router.unregister")
 
 	c.Assert(len(unregistrations), Not(Equals), 0)
-	c.Assert(string(unregistrations[0].Payload), Equals, `{"uris":["abc"],"host":"1.2.3.4","port":123}`)
+	c.Assert(string(unregistrations[0].Payload), Equals,
+		`{"uris":["abc"],"host":"1.2.3.4","port":123,"private_instance_id":"` + routerClient.PrivateInstanceId + `"}`)
 }
 
 func (s *RCSuite) TestRouterClientRouterStartHandling(c *C) {


### PR DESCRIPTION
I was trying to integrate [route-registrar-boshrelease](https://github.com/cloudfoundry-community/route-registrar-boshrelease) into a custom bosh release for a component that needs to be loadbalanced with sticky sessions.

I noticed that the gorouter's sticky session feature (based on JSESSIONID) was not working when using route-registrar. This stems from the fact that the gorouter [only enables sticky sessions when private instance id is given](https://github.com/cloudfoundry/gorouter/blob/7f34e545ed92f7b018f15cf2b3827a2a72d394d1/proxy/proxy.go#L247) upon route registration.

This PR automatically adds the `private_instance_id` when registering the route. This is similar to what cf-registrar does [(it also generates a UUID as `private_instance_id` whenever it is started)](https://github.com/cloudfoundry/cf-registrar/blob/20fdf4c15553eb90855300a81e276659c9dbd2f0/bin/cf-registrar#L41).

Since route-registrar uses gibson to communicate with the router, this would allow route-registrar for registration of sticky-session enabled routes (thus truly replacing cf-registrar).

