### PR TITLE
Upgrade gibson to use new yagnats with apcera wrapper

### DIFF
--- a/router_client_test.go
+++ b/router_client_test.go
@@ -3,7 +3,7 @@ package gibson
 import (
 	"time"
 
-	"github.com/cloudfoundry/yagnats"
+	"github.com/apcera/nats"
 	"github.com/cloudfoundry/yagnats/fakeyagnats"
 	. "launchpad.net/gocheck"
 )
@@ -15,97 +15,64 @@ func init() {
 }
 
 func (s *RCSuite) TestRouterClientRegistering(c *C) {
-	mbus := fakeyagnats.New()
+	mbus := fakeyagnats.Connect()
 
 	routerClient := NewCFRouterClient("1.2.3.4", mbus)
 
 	routerClient.Register(123, "abc")
 
-	registrations := mbus.PublishedMessages["router.register"]
+	registrations := mbus.PublishedMessages("router.register")
 
 	c.Assert(len(registrations), Not(Equals), 0)
-	c.Assert(string(registrations[0].Payload), Equals, `{"uris":["abc"],"host":"1.2.3.4","port":123}`)
+	c.Assert(string(registrations[0].Data), Equals, `{"uris":["abc"],"host":"1.2.3.4","port":123}`)
 }
 
 func (s *RCSuite) TestRouterClientUnregistering(c *C) {
-	mbus := fakeyagnats.New()
+	mbus := fakeyagnats.Connect()
 
 	routerClient := NewCFRouterClient("1.2.3.4", mbus)
 
 	routerClient.Unregister(123, "abc")
 
-	unregistrations := mbus.PublishedMessages["router.unregister"]
+	unregistrations := mbus.PublishedMessages("router.unregister")
 
 	c.Assert(len(unregistrations), Not(Equals), 0)
-	c.Assert(string(unregistrations[0].Payload), Equals, `{"uris":["abc"],"host":"1.2.3.4","port":123}`)
+	c.Assert(string(unregistrations[0].Data), Equals, `{"uris":["abc"],"host":"1.2.3.4","port":123}`)
 }
 
 func (s *RCSuite) TestRouterClientRouterStartHandling(c *C) {
-	mbus := fakeyagnats.New()
+	mbus := fakeyagnats.Connect()
+
+	mbus.WhenSubscribing("router.start", func(handler nats.MsgHandler) error {
+		handler(&nats.Msg{
+			Data: []byte(`{"minimumRegisterIntervalInSeconds":1}`),
+		})
+
+		return nil
+	})
 
 	routerClient := NewCFRouterClient("1.2.3.4", mbus)
 
 	err := routerClient.Greet()
 	c.Assert(err, IsNil)
 
-	startCallback := mbus.Subscriptions["router.start"][0]
-	startCallback.Callback(&yagnats.Message{
-		Payload: []byte(`{"minimumRegisterIntervalInSeconds":1}`),
-	})
-
 	routerClient.Register(123, "abc")
 
-	c.Assert(len(mbus.PublishedMessages["router.register"]), Equals, 1)
+	c.Assert(len(mbus.PublishedMessages("router.register")), Equals, 1)
 
 	time.Sleep(600 * time.Millisecond)
 
-	c.Assert(len(mbus.PublishedMessages["router.register"]), Equals, 1)
+	c.Assert(len(mbus.PublishedMessages("router.register")), Equals, 1)
 
 	time.Sleep(600 * time.Millisecond)
 
-	c.Assert(len(mbus.PublishedMessages["router.register"]), Equals, 2)
+	c.Assert(len(mbus.PublishedMessages("router.register")), Equals, 2)
 
 	time.Sleep(600 * time.Millisecond)
 
-	c.Assert(len(mbus.PublishedMessages["router.register"]), Equals, 2)
+	c.Assert(len(mbus.PublishedMessages("router.register")), Equals, 2)
 
 	time.Sleep(600 * time.Millisecond)
 
-	c.Assert(len(mbus.PublishedMessages["router.register"]), Equals, 3)
-}
-
-func (s *RCSuite) TestRouterClientGreeting(c *C) {
-	mbus := fakeyagnats.New()
-
-	routerClient := NewCFRouterClient("1.2.3.4", mbus)
-
-	routerClient.Register(123, "abc")
-
-	err := routerClient.Greet()
-	c.Assert(err, IsNil)
-
-	greetMsg := mbus.PublishedMessages["router.greet"][0]
-
-	greetCallback := mbus.Subscriptions[greetMsg.ReplyTo][0]
-	greetCallback.Callback(&yagnats.Message{
-		Payload: []byte(`{"minimumRegisterIntervalInSeconds":1}`),
-	})
-
-	c.Assert(len(mbus.PublishedMessages["router.register"]), Equals, 1)
-
-	time.Sleep(600 * time.Millisecond)
-
-	c.Assert(len(mbus.PublishedMessages["router.register"]), Equals, 1)
-
-	time.Sleep(600 * time.Millisecond)
-
-	c.Assert(len(mbus.PublishedMessages["router.register"]), Equals, 2)
-
-	time.Sleep(600 * time.Millisecond)
-
-	c.Assert(len(mbus.PublishedMessages["router.register"]), Equals, 2)
-
-	time.Sleep(600 * time.Millisecond)
-
-	c.Assert(len(mbus.PublishedMessages["router.register"]), Equals, 3)
+	c.Assert(len(mbus.PublishedMessages("router.register")), Equals, 3)
 }


### PR DESCRIPTION
Made some gibson updates to be compatible with the latest and greatest yagnats. This is so we can use the new Apcera NATS client. Gibson is currently using deprecated yagnats functionality.

Removed extraneous test as it's no longer possible to get to the callback using `apcera/nats Msg` like it was with a `yagnats Message`


CC @cholick