### PR TITLE
Support registering and deregistering multiple URIs at a time.

### DIFF
--- a/registry.go
+++ b/registry.go
@@ -36,6 +36,31 @@ func (r *Registry) Unregister(port int, uri string) {
 	}
 }
 
+func (r *Registry) RegisterAll(port int, uris []string) {
+	r.lock.Lock()
+	defer r.lock.Unlock()
+
+	if r.routes[port] == nil {
+		r.routes[port] = make(map[string]bool)
+	}
+
+	for _, uri := range uris {
+		r.routes[port][uri] = true
+	}
+}
+
+func (r *Registry) UnregisterAll(port int, uris []string) {
+	r.lock.Lock()
+	defer r.lock.Unlock()
+
+	for _, uri := range uris {
+		delete(r.routes[port], uri)
+		if len(r.routes[port]) == 0 {
+			delete(r.routes, port)
+		}
+	}
+}
+
 func (r *Registry) InParallel(callback func(int, []string)) (count int) {
 	r.lock.RLock()
 	defer r.lock.RUnlock()

--- a/router_client.go
+++ b/router_client.go
@@ -14,7 +14,9 @@ import (
 type RouterClient interface {
 	Greet() error
 	Register(port int, uri string) error
+	RegisterAll(port int, uris []string) error
 	Unregister(port int, uri string) error
+	UnregisterAll(port int, uris []string) error
 }
 
 type CFRouterClient struct {
@@ -81,6 +83,16 @@ func (r *CFRouterClient) Register(port int, uri string) error {
 func (r *CFRouterClient) Unregister(port int, uri string) error {
 	r.registry.Unregister(port, uri)
 	return r.sendRegistryMessage("router.unregister", port, []string{uri})
+}
+
+func (r *CFRouterClient) RegisterAll(port int, uris []string) error {
+	r.registry.RegisterAll(port, uris)
+	return r.sendRegistryMessage("router.register", port, uris)
+}
+
+func (r *CFRouterClient) UnregisterAll(port int, uris []string) error {
+	r.registry.UnregisterAll(port, uris)
+	return r.sendRegistryMessage("router.unregister", port, uris)
 }
 
 func (r *CFRouterClient) handleGreeting(greeting *nats.Msg) {


### PR DESCRIPTION
This is required to support the current feature set of cf-release, where the [route registrar job](http://bosh.io/jobs/route_registrar?source=github.com/cloudfoundry/cf-release&version=226#p=route_registrar.routes) allows multiple URIs for a given port.

[#110684012]
